### PR TITLE
Fix missing tools jar, add github workflow and add how to use for newer versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [ * ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout repo
+
+    - name: Set up JDK 17 (LTS)
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+        cache: maven
+
+    - name: Build with Maven
+      run: mvn install
+
+    - uses: actions/upload-artifact@v2
+      name: Upload Artifact
+      with:
+        name: ChatItem.jar
+        path: target/ChatItem-*.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 
 on:
-  push:
-    branches: [ * ]
+  - push
+  - pull_request
 
 jobs:
   build:
@@ -26,5 +26,5 @@ jobs:
     - uses: actions/upload-artifact@v2
       name: Upload Artifact
       with:
-        name: ChatItem.jar
-        path: target/ChatItem-*.jar
+        name: WarmRoast
+        path: target/warmroast-*.jar

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ WarmRoast is an easy-to-use CPU sampling tool for JVM applications, but particul
 
 **Download Latest Version:** http://builds.enginehub.org/job/warmroast/last-successful/
 
-Java 7 and above is required to use WarmRoast.
-
 Screenshots
 -----------
 
@@ -23,6 +21,14 @@ Screenshots
 
 Usage
 -----
+
+## For Java 9 and newer
+
+The `tools.jar` is automatically included into JDK's since Java 9. You only should use something like this:
+
+    java -cp warmroast-1.0.0-SNAPSHOT.jar com.sk89q.warmroast.WarmRoast --thread "Server thread"
+
+## For Java 7 & 8
 
 1. Note the path of your JDK.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ WarmRoast is an easy-to-use CPU sampling tool for JVM applications, but particul
  * See the percentage of CPU time for each method relative to its parent methods.
  * Maintains style and function with use of "File -> Save As" (in tested browsers).
 
-**Download Latest Version:** http://builds.enginehub.org/job/warmroast/last-successful/
+### Download
+
+**Latest release**: [here](../../releases)
+
+**Latest build**: [here](../../actions/workflows/build.yml)
 
 Screenshots
 -----------

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
   <version>1.0.0-SNAPSHOT</version>
   <name>WarmRoast</name>
   <url>http://www.sk89q.com</url>
+
   <scm>
     <connection>scm:git:git://github.com/sk89q/warmroast.git</connection>
     <url>https://github.com/sk89q/warmroast</url>
@@ -101,59 +102,10 @@
                   </excludes>
                 </filter>
               </filters>
-              <artifactSet>
-                <excludes>
-                  <exclude>com.sun:tools</exclude>
-                </excludes>
-              </artifactSet>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>tools-default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <file>
-          <exists>${java.home}/../lib/tools.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <toolsJar>${java.home}/../lib/tools.jar</toolsJar>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <version>1.6.0</version>
-          <scope>system</scope>
-          <systemPath>${toolsJar}</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>tools-mac</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <file>
-          <exists>${java.home}/../Classes/classes.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <toolsJar>${java.home}/../Classes/classes.jar</toolsJar>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <version>1.6.0</version>
-          <scope>system</scope>
-          <systemPath>${toolsJar}</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
1) Fix tools jar missing. Since Java 9 it have been removed, and no longer usefull.
2) Make auto run, for people that are looking for download.
3) Link for download have been updated
4) A way to use this with Java 9 added in readme

Fixes #7, fixes #15, fixes #17 and fixes #19